### PR TITLE
Accept JSON for extraParameters.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,7 @@ before_install:
 
     - mkdir -p $HOME/.cache/node_modules || true
     - ln -sf $HOME/.cache/node_modules .
-    # - nvm install v2.3.3
-    - nvm install v4.4.7
+    - nvm install v2.3.3
     - npm install -g npm
     - node --version
     - npm --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ before_install:
 
     - mkdir -p $HOME/.cache/node_modules || true
     - ln -sf $HOME/.cache/node_modules .
-    - nvm install v2.3.3
+    # - nvm install v2.3.3
+    - nvm install v4.4.7
     - npm install -g npm
     - node --version
     - npm --version


### PR DESCRIPTION
extraParameters also accepts url query-encoded strings as before.  If called directly from python, it also accepts a Python dictionary.