### PR TITLE
Change jsonarray output format name to jsonlines.

### DIFF
--- a/plugin_tests/file_test.py
+++ b/plugin_tests/file_test.py
@@ -813,8 +813,8 @@ class FileTest(base.TestCase):
             fileId, ), user=self.user, params=params)
         self.assertStatusOk(resp)
         self.assertEqual(resp.json[4]['town'], 'AGAWAM')
-        # JSON Array format
-        params['format'] = 'JSONArray'
+        # JSON Lines format
+        params['format'] = 'JSON_Lines'
         resp = self.request(path='/file/%s/database/select' % (
             fileId, ), user=self.user, params=params, isJson=False)
         self.assertStatusOk(resp)

--- a/server/query.py
+++ b/server/query.py
@@ -15,7 +15,7 @@ dbFormatList = {
     'dict': 'application/json',
     'csv': 'text/csv',
     'json': 'application/json',  # Same as the data component of dict
-    'jsonarray': 'text/plain',
+    'jsonlines': 'text/plain',
 }
 
 
@@ -89,9 +89,9 @@ def convertSelectDataToJson(result, *args, **kargs):
     return data
 
 
-def convertSelectDataToJsonarray(result, dumpFunc=json.dumps, *args, **kargs):
+def convertSelectDataToJsonlines(result, dumpFunc=json.dumps, *args, **kargs):
     """
-    Convert data in list format to the Mongo JSONArray format.  This has each
+    Convert data in list format to the Mongo JSON lines format.  This has each
     line be one data item represented as an independent JSON document.  The
     column names are used as the keys for each row.
 
@@ -253,7 +253,7 @@ def preferredFormat(format):
     :param format: the proposed format.
     :returns: the canonical format name or None if unknown.
     """
-    format = str(format or 'list').lower()
+    format = str(format or 'list').replace('_', '').lower()
     if format not in dbFormatList:
         return None
     return format


### PR DESCRIPTION
Also, allow _ to be disregarded in format names.  This means that json_lines, jsonlines, and JSONLines all map to the same format.