### PR TITLE
Make a clear distinction between limit=0 and limit='none'.

### DIFF
--- a/plugin_tests/assetstore_test.py
+++ b/plugin_tests/assetstore_test.py
@@ -456,6 +456,59 @@ class AssetstoreTest(base.TestCase):
                                    'JSON-encoded dictionary, or a url'):
             adapter.downloadFile(townFile, headers=False, extraParameters=6)
 
+        # Test with 0 and none limits
+        params = {
+            'format': 'list',
+            'fields': 'town,pop2000',
+            'sort': 'pop2000',
+            'filters': json.dumps([{
+                'field': 'pop2000', 'operator': '>', 'value': 25000}]),
+        }
+        params['limit'] = 0
+        func = adapter.downloadFile(
+            townFile, headers=False, extraParameters=params)
+        jsondata = ''.join([part for part in func()])
+        data = json.loads(jsondata)
+        self.assertEqual(data['datacount'], 0)
+        self.assertEqual(data['fields'], ['town', 'pop2000'])
+        # It shouldn't matter if we ask for this via json, query, or object
+        func = adapter.downloadFile(
+            townFile, headers=False,
+            extraParameters=urllib.parse.urlencode(params))
+        self.assertEqual(''.join([part for part in func()]), jsondata)
+        func = adapter.downloadFile(
+            townFile, headers=False, extraParameters=json.dumps(params))
+        self.assertEqual(''.join([part for part in func()]), jsondata)
+
+        params['limit'] = 'none'
+        func = adapter.downloadFile(
+            townFile, headers=False, extraParameters=params)
+        jsondata = ''.join([part for part in func()])
+        data = json.loads(jsondata)
+        self.assertEqual(data['datacount'], 71)
+        self.assertEqual(data['fields'], ['town', 'pop2000'])
+        # It shouldn't matter if we ask for this via json, query, or object
+        func = adapter.downloadFile(
+            townFile, headers=False,
+            extraParameters=urllib.parse.urlencode(params))
+        self.assertEqual(''.join([part for part in func()]), jsondata)
+        func = adapter.downloadFile(
+            townFile, headers=False, extraParameters=json.dumps(params))
+        self.assertEqual(''.join([part for part in func()]), jsondata)
+
+        # None can also be used as unlimited
+        params['limit'] = None
+        func = adapter.downloadFile(
+            townFile, headers=False, extraParameters=params)
+        self.assertEqual(''.join([part for part in func()]), jsondata)
+        func = adapter.downloadFile(
+            townFile, headers=False,
+            extraParameters=urllib.parse.urlencode(params))
+        self.assertEqual(''.join([part for part in func()]), jsondata)
+        func = adapter.downloadFile(
+            townFile, headers=False, extraParameters=json.dumps(params))
+        self.assertEqual(''.join([part for part in func()]), jsondata)
+
     def testAssetstoreFileCopy(self):
         # Create assetstore
         resp = self.request(path='/assetstore', method='POST', user=self.admin,

--- a/server/assetstore.py
+++ b/server/assetstore.py
@@ -199,6 +199,8 @@ class DatabaseAssetstoreAdapter(AbstractAssetstoreAdapter):
                     'The extraParameters field must either be a dictionary, a '
                     'JSON-encoded dictionary, or a url query-encoded string.')
             params.update(extraParameters)
+            if params.get('limit', 'notpresent') is None:
+                params['limit'] = 'none'
         resultFunc, mimeType = queryDatabase(file.get('_id'), dbinfo, params)
         file['mimeType'] = mimeType
 

--- a/server/dbs/mongo.py
+++ b/server/dbs/mongo.py
@@ -81,8 +81,6 @@ class MongoConnector(base.DatabaseConnector):
         self.conn = None
 
     def performSelect(self, fields, queryProps={}, filters=[], client=None):
-        coll = self.connect()
-
         result = super(MongoConnector, self).performSelect(
             fields, queryProps, filters)
 
@@ -115,12 +113,17 @@ class MongoConnector(base.DatabaseConnector):
         elif 'filter' in opts:
             del opts['filter']
 
-        results = coll.find(**opts)
-        results = [convertFields(result['fields'], row) for row in results]
+        if queryProps.get('limit') == 0:
+            result['data'] = []
+        else:
+            coll = self.connect()
 
-        result['data'] = results
+            results = coll.find(**opts)
+            results = [convertFields(result['fields'], row) for row in results]
 
-        self.disconnect()
+            result['data'] = results
+
+            self.disconnect()
 
         return result
 

--- a/server/query.py
+++ b/server/query.py
@@ -277,8 +277,9 @@ def queryDatabase(id, dbinfo, params):
         raise DatabaseConnectorException('Failed to connect to database.')
     fields = conn.getFieldInfo()
     queryProps = {
-        'limit': int(50 if params.get('limit') is None
-                     else params.get('limit')),
+        'limit':
+            six.MAXSIZE if params.get('limit') in ('none', 'None') else int(
+                50 if params.get('limit') is None else params.get('limit')),
         'offset': int(params.get('offset', 0) or 0),
         'sort': getSortList(conn, fields, params.get('sort'),
                             params.get('sortdir')),

--- a/server/rest.py
+++ b/server/rest.py
@@ -140,8 +140,8 @@ class DatabaseFileResource(File):
     @describeRoute(
         Description('Get data from a database link.')
         .param('id', 'The ID of the file.', paramType='path')
-        .param('limit', 'Result set size limit (default=50).',
-               required=False, dataType='int')
+        .param('limit', 'Result set size limit (default=50).  Use \'none\' '
+               'to return all rows (0 returns 0 rows)', required=False)
         .param('offset', 'Offset into result set (default=0).',
                required=False, dataType='int')
         .param('sort', 'Either a field to sort the results by or a JSON list '
@@ -329,8 +329,8 @@ class DatabaseAssetstoreResource(Resource):
                'JSON list of fields and directions.', required=False)
         .param('fields', 'The default fields to return.', required=False)
         .param('filters', 'The default fields to return.', required=False)
-        .param('limit', 'The default limit of rows to return.', required=False,
-               dataType='int')
+        .param('limit', 'The default limit of rows to return.  Use \'none\' '
+               'to return all rows (0 returns 0 rows)', required=False)
         .param('format', 'The default format return.', required=False,
                enum=list(dbFormatList))
         .param('progress', 'Whether to record progress on this operation ('


### PR DESCRIPTION
limit='none' (or null in javascript, None in Python) explicitly returns all results.  limit=0 returns NO results (but may return the column headers, depending on output format).