### PR TITLE
Allow negative numbers for limits to signal no limit.

### DIFF
--- a/plugin_tests/assetstore_test.py
+++ b/plugin_tests/assetstore_test.py
@@ -249,12 +249,12 @@ class AssetstoreTest(base.TestCase):
             method='PUT', user=self.admin, params=params)
         self.assertStatusOk(resp)
         # Setting a bad limit should throw an error
-        params['limit'] = -4
+        params['limit'] = 'not an int'
         resp = self.request(
             path='/database_assetstore/%s/import' % str(assetstore1['_id']),
             method='PUT', user=self.admin, params=params)
         self.assertStatus(resp, 400)
-        self.assertIn('positive integer', resp.json['message'])
+        self.assertIn('must be an integer', resp.json['message'])
         del params['limit']
 
         # Import a table from mongo
@@ -291,7 +291,7 @@ class AssetstoreTest(base.TestCase):
         with self.assertRaises(GirderException):
             adapter.importData(
                 self.publicFolder, 'folder',
-                {'tables': ['towns'], 'limit': -4},
+                {'tables': ['towns'], 'limit': 'not an int'},
                 progress.noProgress, self.admin)
         # Change the file we made for towns to remove the marker that it was
         # imported to prvent import from updating it.

--- a/server/assetstore.py
+++ b/server/assetstore.py
@@ -329,12 +329,11 @@ class DatabaseAssetstoreAdapter(AbstractAssetstoreAdapter):
                     'because it wasn\'t imported.' % name)
             # Validate the limit parameter
             try:
-                if (params.get('limit') not in (None, '') and
-                        int(params.get('limit')) <= 0):
-                    raise ValueError()
+                if params.get('limit') not in (None, ''):
+                    params['limit'] = int(params['limit'])
             except ValueError:
                 raise GirderException(
-                    'limit must be empty or a positive integer')
+                    'limit must be empty or an integer')
             # Set or replace the database parameters for the file
             dbinfo['imported'] = True
             for key in ('sort', 'fields', 'filters', 'format', 'limit'):

--- a/server/dbs/base.py
+++ b/server/dbs/base.py
@@ -301,7 +301,7 @@ class DatabaseConnector(object):
         """
         Perform a select query.  The results are passed back as a dictionary
         with the following values:
-          limit: the limit used in the query
+          limit: the limit used in the query.  Negative or None for all.
           offset: the offset used in the query
           sort: the list of sort parameters used in the query.
           fields: a list of the fields that are being returned in the order

--- a/server/dbs/mongo.py
+++ b/server/dbs/mongo.py
@@ -138,6 +138,8 @@ class MongoConnector(base.DatabaseConnector):
         if queryProps.get('limit') == 0:
             result['data'] = []
         else:
+            if queryProps.get('limit') < 0:
+                opts['limit'] = 0
             coll = self.connect()
             log.info('Query: %s', bson.json_util.dumps(
                 opts, check_circular=False, separators=(',', ':'),

--- a/server/dbs/sqlalchemydb.py
+++ b/server/dbs/sqlalchemydb.py
@@ -373,7 +373,8 @@ class SQLAlchemyConnector(base.DatabaseConnector):
                     sortCol = sortCol.desc()
                 sortList.append(sortCol)
             query = query.order_by(*sortList)
-        if 'limit' in queryProps:
+        if (queryProps.get('limit') is not None and
+                int(queryProps['limit']) >= 0):
             query = query.limit(int(queryProps['limit']))
         if 'offset' in queryProps:
             query = query.offset(int(queryProps['offset']))

--- a/server/query.py
+++ b/server/query.py
@@ -304,7 +304,7 @@ def queryDatabase(id, dbinfo, params):
     fields = conn.getFieldInfo()
     queryProps = {
         'limit':
-            six.MAXSIZE if params.get('limit') in ('none', 'None') else int(
+            (-1) if params.get('limit') in ('none', 'None') else int(
                 50 if params.get('limit') is None else params.get('limit')),
         'offset': int(params.get('offset', 0) or 0),
         'sort': getSortList(conn, fields, params.get('sort'),

--- a/server/rest.py
+++ b/server/rest.py
@@ -141,7 +141,8 @@ class DatabaseFileResource(File):
         Description('Get data from a database link.')
         .param('id', 'The ID of the file.', paramType='path')
         .param('limit', 'Result set size limit (default=50).  Use \'none\' '
-               'to return all rows (0 returns 0 rows)', required=False)
+               'or a negative value to return all rows (0 returns 0 rows)',
+               required=False)
         .param('offset', 'Offset into result set (default=0).',
                required=False, dataType='int')
         .param('sort', 'Either a field to sort the results by or a JSON list '
@@ -330,7 +331,8 @@ class DatabaseAssetstoreResource(Resource):
         .param('fields', 'The default fields to return.', required=False)
         .param('filters', 'The default fields to return.', required=False)
         .param('limit', 'The default limit of rows to return.  Use \'none\' '
-               'to return all rows (0 returns 0 rows)', required=False)
+               'or a negative value to return all rows (0 returns 0 rows)',
+               required=False)
         .param('format', 'The default format return.', required=False,
                enum=list(dbFormatList))
         .param('progress', 'Whether to record progress on this operation ('
@@ -359,13 +361,11 @@ class DatabaseAssetstoreResource(Resource):
                                     'name of a table or a JSON list.')
         else:
             tables = [tables]
-        if params.get('limit'):
+        if params.get('limit') is not None:
             try:
                 params['limit'] = int(params['limit'])
-                if params['limit'] <= 0:
-                    raise ValueError()
             except ValueError:
-                raise RestException('The limit must be a positive integer.')
+                raise RestException('The limit must be an integer or "none".')
         if '' in tables:
             tables = ['']
         tables = self._parseTableList(tables, assetstore)
@@ -389,6 +389,6 @@ class DatabaseAssetstoreResource(Resource):
                 'sort': params.get('sort'),
                 'fields': params.get('fields'),
                 'filters': params.get('filters'),
-                'limit': params.get('limit') or None,
+                'limit': params.get('limit'),
                 'format': format
                 }, ctx, user)


### PR DESCRIPTION
This also works around a problem when Python's MAXSIZE is too large for Mongo to handle properly by avoiding setting a limit when no limit is desired.